### PR TITLE
Mount the airflow data directory into neo4j & Networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config/
 dags/
 logs/
 plugins/
+**.DS_STORE

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD_FILES := docker-compose.yml -f airflow/docker-compose.yml
+BUILD_FILES := airflow/docker-compose.yml -f docker-compose.yml
 
 up: # Bring the stack up
 	docker-compose -f ${BUILD_FILES} up -d $(c)

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,3 @@ up: # Bring the stack up
 
 down: # Bring the stack down and remove artifacts
 	docker-compose -f ${BUILD_FILES} down -v $(c)
-	rm -r logs config dags plugins

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ up: # Bring the stack up
 	docker-compose -f ${BUILD_FILES} up -d $(c)
 
 down: # Bring the stack down and remove artifacts
-	docker-compose -f ${BUILD_FILES} down $(c)
+	docker-compose -f ${BUILD_FILES} down -v $(c)
 	rm -r logs config dags plugins

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ sh fetch-repositories.sh
 
 Then, set the volume `- ~/deployment/airflow/data/:/var/lib/neo4j/import` to the correct path on the host machine. This should be mounting the `data/` folder from airflow.
 
+Next, read through the airflow README file for any steps to take before running.
+
 Finally, start the stack with
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ Repository for running the Mexico Map project stack.
 
 ## Deploying
 
-To start the stack,
+To start the stack, first fetch the related projects
 
 ```bash
 sh fetch-repositories.sh
-make start
+```
+
+Then, set the volume `- ~/deployment/airflow/data/:/var/lib/neo4j/import` to the correct path on the host machine. This should be mounting the `data/` folder from airflow.
+
+Finally, start the stack with
+
+```
+make up
 ```
 
 To tear it down,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
       - "7687:7687"
     environment:
       - NEO4J_AUTH=neo4j/neo4j222
+    volumes:
+      - ~/deployment/airflow/data/:/var/lib/neo4j/import

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   neo4j:
     image: neo4j:5.11.0-community-bullseye
+    container_name: neo4j
     ports:
       - "7474:7474"
       - "7687:7687"
@@ -8,3 +9,10 @@ services:
       - NEO4J_AUTH=neo4j/neo4j222
     volumes:
       - ~/deployment/airflow/data/:/var/lib/neo4j/import
+    networks:
+      - mexico_net
+networks:
+  mexico_net:
+
+
+  


### PR DESCRIPTION
The Airflow DAGS download & output CSV files, which neo4j needs to access from its _imports_ directory. This change mounts the shared folder. Note that you have to do some matching against the location of the directory on disk, within the dockerfile.

This PR also includes a change to add neo4j to the docker network, which is shared with airflow